### PR TITLE
Enable arm64 build, add R,W tags to listed locators

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,8 +3,6 @@
 .github/
 .git/
 .github/
-fognav_msgs/.git/
-fognav_msgs/.github/
 .vscode/
 .dockerignore
 .gitignore

--- a/.github/workflows/fastdds-locator-monitor.yaml
+++ b/.github/workflows/fastdds-locator-monitor.yaml
@@ -18,6 +18,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: amd64, arm64
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -40,7 +45,9 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,10 @@ COPY fastdds_statistics_backend.repos $UNDERLAY_WS/src/fastdds_monitor_tutorial/
 
 # Import the underlay dependencies that doesn't exist in SDK image
 RUN vcs import ./src/ < $UNDERLAY_WS/src/fastdds_monitor_tutorial/underlay.repos
+COPY locator.patch $UNDERLAY_WS/src/fastdds_statistics_backend/locator.patch
 
 RUN ls -la $UNDERLAY_WS/src && \
+    git -C $UNDERLAY_WS/src/fastdds_statistics_backend apply locator.patch && \
     . /usr/bin/ros_setup.bash && \
     colcon build --cmake-args -DBUILD_TESTING=0
 

--- a/locator.patch
+++ b/locator.patch
@@ -1,0 +1,44 @@
+diff --git a/src/cpp/StatisticsBackend.cpp b/src/cpp/StatisticsBackend.cpp
+index d0a041b..f3eef37 100644
+--- a/src/cpp/StatisticsBackend.cpp
++++ b/src/cpp/StatisticsBackend.cpp
+@@ -531,7 +531,7 @@ Info StatisticsBackend::get_info(
+             info[QOS_INFO_TAG] = participant->qos;
+ 
+             // Locators associated to endpoints
+-            std::set<std::string> locator_set;
++            std::map<std::string, std::set<std::string>> locator_map;
+ 
+             // Writers registered in the participant
+             for (const auto& writer : participant->data_writers)
+@@ -539,7 +539,7 @@ Info StatisticsBackend::get_info(
+                 // Locators associated to each writer
+                 for (const auto& locator : writer.second.get()->locators)
+                 {
+-                    locator_set.insert(locator.second.get()->name);
++                    locator_map[locator.second.get()->name].insert("W");
+                 }
+             }
+ 
+@@ -549,14 +549,18 @@ Info StatisticsBackend::get_info(
+                 // Locators associated to each reader
+                 for (const auto& locator : reader.second.get()->locators)
+                 {
+-                    locator_set.insert(locator.second.get()->name);
++                    locator_map[locator.second.get()->name].insert("R");
+                 }
+             }
+ 
+             DatabaseDump locators = DatabaseDump::array();
+-            for (const auto& locator : locator_set)
++            for (const auto& locator : locator_map)
+             {
+-                locators.push_back(locator);
++                std::string sources = std::accumulate(std::next(locator.second.begin()), locator.second.end(), *locator.second.begin(),
++                    [](std::string a, std::string b) {
++                        return a + ',' + b;
++                    });
++                locators.push_back(locator.first + " [" + sources + "]");
+             }
+             info[LOCATOR_CONTAINER_TAG] = locators;
+             break;


### PR DESCRIPTION
## Changelog:
- Enable arm64 builds
- Add patch to the `fastdds_statistics_backend` to append `[R]`, `[W]`, `[R,W]` suffix to the locators to distinguish reader/writer locators.